### PR TITLE
pat / tasks/24525834-enhancements --- added ability to filter by cont…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Islandora Datastream Dedup 
+# Islandora Datastream Dedup
 
 ## Introduction
 
-This module provides a drush command that permits permanently removing older datastream versions, leaving only the most recent. It was developed for a case where multiple versions of very large OBJ datastreams had unintentionally been created and needed to be removed to recover server storage space.
+This module provides a drush command that permits permanently removing older datastream versions, leaving only the most recent.
+It was developed for a case where multiple versions of very large OBJ datastreams had unintentionally been created and needed
+to be removed to recover server storage space.
 
 ## Requirements
 
@@ -22,25 +24,33 @@ No configuration is required for this module.
 
 ### Usage
 
-This module provides a single drush command: `dedup-datastreams` (alias `ddds`)
+```$xslt
+drush dedup-datastreams --help
+Removes older versions of a datastream, preserving the current version. Additional options to remove all datastreams, preview-only, filter by collection, content model.
+
+Examples:
+ drush ddds -u 1 --ds=OBJ                Delete duplicate OBJ datastreams whose mimetype is "image/jpeg", and show timing statistics.
+ --mimetype="image/jpeg" --op=nuke-dups
+ --timer
+ drush ddds  -u 1 --ds=OBJ               Display stats about duplicate OBJ datastreams where the mimetype is "image/tiff". No datastreams will be deleted
+ --mimetype="image/tiff"
 
 Options:
+ --cm                                      Optional: Comma-separated list of content model pids. Restricts datastream deduping to objects that match these content-models.
+                                           E.g. `--cm=islandora:newspaperPageCModel,islandora:pageCModel
+ --collection-pids                         Optional: Provide one or more collection pids to include children of. Separate multiple pids with commas
+ --collection-pids-file                    Optional: Provide path to a file with collection pids to exclude children of. One pid per line.
+ --ds                                      A datastream identifier, e.g. "TN" or "OBJ" Required.
+ --exclude-pids                            Optional: Negate the collection pids, i.e. exclude children of the pid/pids provided by collection-pids-file and collection-pid.
+ --mimetype                                Optional: The mimetype that the datastream uses. E.g. "image/jpeg", or "image/tiff"
+ --op                                      Optional: This must be set to "nuke-dups" or "nuke-all" to actually perform deletion of the datastreams. Acceptable values are:
+                                           "preview-dups" (report on duplicate datastreams), "preview-all" (report on all copies of the datastream), "nuke-dups" (delete
+                                           duplicate datastreams), and "nuke-all" (delete all copies of the datastream). If not provided, defaults to "preview-dups".
+ --timer                                   Optional: Output time stats.
 
-| Option | Info |
-|---|---|
-| --ds | **[Required]** A datastream identifier, e.g. `--ds=TN` or `--ds=OBJ` |
-| --mimetype | **[Required]** The mimetype that the datastream uses. E.g. `--mimetyp="image/jpeg"` |
-| --nuke | **[Optional]** This flag must be set to actually perform deletion of the datastreams, e.g. `--nuke`. Otherwise you will only see a report that previews what would have been deleted. |
-| --timer | **[Optional]** Output time stats, e.g. `--timer`. |
+Aliases: ddds
 
-
-## Examples:
-
-- `drush ddds -u 1 --ds=OBJ --mimetype="image/jpeg" --nuke --timer`
-   Delete duplicate OBJ datastreams whose mimetype is "image/jpeg", and show timing statistics.
-- `drush ddds  -u 1 --ds=OBJ --mimetype="image/tiff"`
-   Display stats about duplicate OBJ datastreams where the mimetype is "image/tiff". No datastreams will be deleted
-
+```
 
 
 ## Troubleshooting/Issues

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1,6 +1,10 @@
 <?php
 
-function _datastream_dedup($op = 'preview', $dsid = 'OBJ', $options = array()) {
+function _datastream_dedup($op, $dsid = 'OBJ', $options = array()) {
+
+  $mode = $op['mode']; // preview or nuke
+  $scope = $op['scope']; // dups or all
+  $leave = $scope === 'all' ? 0 : 1; // leave 1 if dups, otherwise leave zero
 
   $query = array();
   $timer = FALSE;
@@ -28,8 +32,16 @@ function _datastream_dedup($op = 'preview', $dsid = 'OBJ', $options = array()) {
   foreach($options as $key => $value) {
     switch($key) {
       case 'mimetype':
-        $mimetype = $value;
-        $query[] = 'fedora_datastream_latest_' . $dsid . '_MIMETYPE_mt:"' . $mimetype . '"';
+        $data = str_getcsv($value);
+        $data = array_map('trim',$data);
+        $mimetypes = array_filter($data);
+        $mimetype_query_ors = array();
+        foreach($mimetypes as $mimetype) {
+          foreach($dsids as $dsid) {
+            $mimetype_query_ors[] = 'fedora_datastream_latest_' . $dsid . '_MIMETYPE_mt:"' . $mimetype . '"';
+          }
+        }
+        $query[] = '(' . implode(' OR ', $mimetype_query_ors) . ')';
       case 'timer':
         $timer = TRUE;
         break;
@@ -55,6 +67,13 @@ function _datastream_dedup($op = 'preview', $dsid = 'OBJ', $options = array()) {
         $data = array_filter($data);
         $pids = array_merge($pids, $data);
         break;
+      case 'cm': {
+        $data = str_getcsv($value);
+        $data = array_map('trim',$data);
+        $content_models = array_filter($data);
+        dpm(compact('content_models'));
+
+      }
     }
   }
 
@@ -66,25 +85,43 @@ function _datastream_dedup($op = 'preview', $dsid = 'OBJ', $options = array()) {
     $query_pids = array();
     foreach($pids as $i => $pid) {
       $query_pids[] = 'RELS_EXT_isMemberOfCollection_uri_s:"info:fedora/' . $pid . '"';
-
-      foreach($dsids as $dsid) {
-        $collection_stats[$pid][$dsid] = $collection_stats_record_template;
-      }
     }
     $query[] = $exclude . '(' . implode(' OR ',$query_pids) . ')';
   }
 
-  $query = implode(' AND ', $query);
+  if(!empty($content_models)) {
+    $query_cms = array();
+    foreach($content_models as $i => $cm) {
+      $query_cms[] = 'RELS_EXT_hasModel_uri_ss:"info:fedora/' . $cm . '"';
+    }
+    $query[] =  '(' . implode(' OR ',$query_cms) . ')';
+  }
 
-  $qp = new IslandoraSolrQueryProcessor();
 
+  $membership_fields = array(
+    'RELS_EXT_isMemberOfCollection_uri_s',
+    'RELS_EXT_isConstituentOf_uri_s',
+    'RELS_EXT_isMemberOf_uri_s',
+    'RELS_EXT_isPageOf_uri_s',
+  );
   $fl = array(
     'PID',
     'fgs_label_s',
   );
+  $ds_size_fields = array();
   foreach($dsids as $dsid_value) {
-    $fl[] = 'RELS_EXT_isMemberOfCollection_uri_s, fedora_datastream_version_' . $dsid_value . '_SIZE_ms';
+    $ds_size_fields[] = 'fedora_datastream_version_' . $dsid_value . '_SIZE_ms';
   }
+  $ds_size_filters = array();
+  foreach($ds_size_fields as $ds_size_field) {
+    $ds_size_filters[] = $ds_size_field . " : [ * TO * ]";
+  }
+  $query[] = "( " . implode(" OR ", $ds_size_filters) . " )";
+  $fl = array_merge($fl, $membership_fields);
+  $fl = array_merge($fl, $ds_size_fields);
+
+  $query = implode(' AND ', $query);
+  $qp = new IslandoraSolrQueryProcessor();
 
   $qp->buildQuery($query);
   $qp->solrParams['fl'] = implode(', ', $fl);
@@ -111,7 +148,7 @@ function _datastream_dedup($op = 'preview', $dsid = 'OBJ', $options = array()) {
     if(drupal_is_cli()) {
       $msg = $t("Preparing to inspect @num objects for duplicate @dsid datastreams@type.", array(
         '@num' => $qp->islandoraSolrResult['response']['numFound'],
-        '@dsid' => $dsid,
+        '@dsid' => implode(',', $dsids),
         '@type' => !empty($mimetype) ? t(' matching the "@mimetype" mimetype', array('@mimetype' => $mimetype)) : '',
       ));
       drush_log($msg, 'ok');
@@ -123,11 +160,21 @@ function _datastream_dedup($op = 'preview', $dsid = 'OBJ', $options = array()) {
       if($timer) timer_stop('ddds_execute_solr_query');
       foreach ($qp->islandoraSolrResult['response']['objects'] as $object_result) {
         $collection_stats['All Objects']['object count']++;
-        $collection_stats[$pid]['object count']++;
-        $pid = str_replace('info:fedora/', '', $object_result['solr_doc']['RELS_EXT_isMemberOfCollection_uri_s']);
+        $pid = "Not a member of any object";
+        foreach($membership_fields as $membership_field) {
+          if(!empty($object_result['solr_doc'][$membership_field]) && !empty(array_intersect_key($object_result['solr_doc'], array_flip($ds_size_fields)))) {
+            $pid = str_replace('info:fedora/', '', $object_result['solr_doc'][$membership_field]);
+            break;
+          }
+        }
         foreach($dsids as $dsid) {
+          if(!isset($collection_stats[$pid][$dsid])) {
+            $collection_stats[$pid][$dsid] = $collection_stats_record_template;
+          }
           if (!empty($object_result['solr_doc']['fedora_datastream_version_' . $dsid . '_SIZE_ms'])) {
 
+            $collection_stats['All Objects'][$dsid]['object count']++;
+            $collection_stats[$pid][$dsid]['object count']++;
             $first_datastream_size = reset($object_result['solr_doc']['fedora_datastream_version_' . $dsid . '_SIZE_ms']);
             $collection_stats['All Objects'][$dsid]['first datastream total size'] += $first_datastream_size;
             $collection_stats[$pid][$dsid]['first datastream total size'] += $first_datastream_size;
@@ -137,37 +184,27 @@ function _datastream_dedup($op = 'preview', $dsid = 'OBJ', $options = array()) {
               $collection_stats['All Objects'][$dsid]['datastream total size'] += $ds_size;
               $collection_stats[$pid][$dsid]['datastream total size'] += $ds_size;
             }
-            if ($op == 'all' || $op == 'dups') {
-              if(user_access('delete fedora objects and datastreams')) {
-                $object = islandora_object_load($object_result['solr_doc']['PID']);
-                if (!empty($object[$dsid])) {
-                  $ds = $object[$dsid];
-                  if ($op == 'all' || ($op == 'dups' && count($object_result['solr_doc']['fedora_datastream_version_' . $dsid . '_SIZE_ms']) > 1)) {
-                    while ($ds->count() > 1) {
-                      $key = $ds->count() - 1;
-                      if($timer) timer_start('ddds_delete');
+            $ds_count = count($object_result['solr_doc']['fedora_datastream_version_' . $dsid . '_SIZE_ms']);
+            $nuke = $mode == 'nuke' && user_access('delete fedora objects and datastreams');
+            $object = islandora_object_load($object_result['solr_doc']['PID']);
+            $ds = $object[$dsid] ?? NULL;
+
+            if ($ds_count > $leave ) {
+                for($key = $ds_count -1; $key >= $leave; $key--) {
+                  if ($nuke && $ds) {
+                    if($timer) timer_start('ddds_delete');
                       unset($ds[$key]);
-                      if($timer) timer_stop('ddds_delete');
-                      $collection_stats['All Objects'][$dsid]['datastreams deleted count']++;
-                      $collection_stats['All Objects']['datastreams deleted count']++;
-                      $collection_stats[$pid]['datastreams deleted count']++;
-                      $collection_stats['All Objects'][$dsid]['datastreams deleted total size'] += $object_result['solr_doc']['fedora_datastream_version_' . $dsid . '_SIZE_ms'][$key];
-                      $collection_stats['All Objects']['datastreams deleted total size'] += $object_result['solr_doc']['fedora_datastream_version_' . $dsid . '_SIZE_ms'][$key];
-                      $collection_stats[$pid][$dsid]['datastreams deleted total size'] += $object_result['solr_doc']['fedora_datastream_version_' . $dsid . '_SIZE_ms'][$key];
-                    }
+                    if($timer) timer_stop('ddds_delete');
                   }
-                  if ($op == 'all') {
-                    drush_log($op, 'ok');
-                    $object->purgeDatastream($dsid);
-                  }
+                  $collection_stats['All Objects'][$dsid]['datastreams deleted count']++;
+                  $collection_stats[$pid][$dsid]['datastreams deleted count']++;
+                  $collection_stats['All Objects'][$dsid]['datastreams deleted total size'] += $object_result['solr_doc']['fedora_datastream_version_' . $dsid . '_SIZE_ms'][$key];
+                  $collection_stats[$pid][$dsid]['datastreams deleted total size'] += $object_result['solr_doc']['fedora_datastream_version_' . $dsid . '_SIZE_ms'][$key];
                 }
               }
-            }
           }
-
         }
       }
-
       if(count($qp->islandoraSolrResult['response']['objects']) > 0 && drupal_is_cli()) {
         $update_msg = $t("Objects checked: @object_count. Datastreams deleted: @deleted", array('@object_count' => $collection_stats['All Objects']['object count'], '@deleted' => $collection_stats['All Objects']['datastreams deleted count']));
         drush_log($update_msg, 'ok');
@@ -182,9 +219,13 @@ function _datastream_dedup($op = 'preview', $dsid = 'OBJ', $options = array()) {
     unset($collection_stats['All Objects']);
     $collection_stats['All Objects'] = $all_objects_stats;
 
-
-    $rows = [['', 'DSID', 'Objects', 'Datastreams', 'File size', 'Dups file size', 'Dups deleted', 'Dups deleted size']];
+    $preview_label = $mode == 'nuke' ? "" : "Preview ";
+    $rows = [['', 'DSID', 'Objects', 'Datastreams', 'Total File Size', 'Dups File Size', $preview_label . 'Datastreams Deleted', $preview_label . 'Deleted Datastream Size']];
     foreach($collection_stats as $id => $stats) {
+      // Insert visual break in table before All Objects summary section.
+      if($id == 'All Objects') {
+        $rows['hr'] = ['---', '---', '---', '---', '---', '---', '---' . '---', '---' . '---'];
+      }
       foreach($dsids as $dsid) {
         $rows[] = array(
           $id,
@@ -192,7 +233,7 @@ function _datastream_dedup($op = 'preview', $dsid = 'OBJ', $options = array()) {
           $stats[$dsid]['object count'],
           $stats[$dsid]['datastream count'],
           format_size($stats[$dsid]['datastream total size']),
-          format_size($stats[$dsid]['datastream total size'] - $stats['first datastream total size']),
+          format_size($stats[$dsid]['datastream total size'] - $stats[$dsid]['first datastream total size']),
           $stats[$dsid]['datastreams deleted count'],
           format_size($stats[$dsid]['datastreams deleted total size']),
         );
@@ -207,5 +248,10 @@ function _datastream_dedup($op = 'preview', $dsid = 'OBJ', $options = array()) {
       $header = array_shift($rows);
       return theme('table', array('header' => $header, 'rows' => $rows));
     }
+  }
+  else {
+    $msg = $t("No objects were found matching these filter criteria.", array());
+    drush_log($msg, 'ok');
+
   }
 }

--- a/islandora_datastream_dedup.drush.inc
+++ b/islandora_datastream_dedup.drush.inc
@@ -3,24 +3,25 @@
 function islandora_datastream_dedup_drush_command() {
 
   $commands['dedup-datastreams'] = array(
-    'description' => 'Removes older versions of a datastream, preserving the current version',
+    'description' => 'Removes older versions of a datastream, preserving the current version. Additional options to remove all datastreams, preview-only, filter by collection, content model.',
     'aliases' => array('ddds'),
     'options' => array(
       'ds' => array(
         'description' => 'A datastream identifier, e.g. "TN" or "OBJ"',
         'required' => TRUE,
       ),
+      'op' => 'Optional: This must be set to "nuke-dups" or "nuke-all" to actually perform deletion of the datastreams. Acceptable values are: "preview-dups" (report on duplicate datastreams), "preview-all" (report on all copies of the datastream), "nuke-dups" (delete duplicate datastreams), and "nuke-all" (delete all copies of the datastream). If not provided, defaults to "preview-dups". ',
       'mimetype' => array(
         'description' => 'Optional: The mimetype that the datastream uses. E.g. "image/jpeg", or "image/tiff"',
       ),
-      'nuke' => 'Optional: This must be set to actually perform deletion of the datastreams. Acceptable values are: "dups" (delete duplicate datastreams), and "all" (delete all copies of the datastream). If neither option is provided, you will see a report that previews what would have been deleted. ',
-      'timer' => 'Optional: Output time stats.',
+      'cm' => 'Optional: Comma-separated list of content model pids. Restricts datastream deduping to objects that match these content-models. E.g. `--cm=islandora:newspaperPageCModel,islandora:pageCModel',
       'collection-pids-file' => 'Optional: Provide path to a file with collection pids to exclude children of. One pid per line.',
       'collection-pids' => 'Optional: Provide one or more collection pids to include children of. Separate multiple pids with commas',
       'exclude-pids' => 'Optional: Negate the collection pids, i.e. exclude children of the pid/pids provided by collection-pids-file and collection-pid.',
+      'timer' => 'Optional: Output time stats.',
     ),
     'examples' => array(
-      'drush ddds -u 1 --ds=OBJ --mimetype="image/jpeg" --nuke=dups --timer' => 'Delete duplicate OBJ datastreams whose mimetype is "image/jpeg", and show timing statistics.',
+      'drush ddds -u 1 --ds=OBJ --mimetype="image/jpeg" --op=nuke-dups --timer' => 'Delete duplicate OBJ datastreams whose mimetype is "image/jpeg", and show timing statistics.',
       'drush ddds  -u 1 --ds=OBJ --mimetype="image/tiff"' => 'Display stats about duplicate OBJ datastreams where the mimetype is "image/tiff". No datastreams will be deleted',
     ),
   );
@@ -34,14 +35,17 @@ function islandora_datastream_dedup_drush_command() {
  */
 function drush_islandora_datastream_dedup_dedup_datastreams() {
   $ds = drush_get_option('ds', 'OBJ');
-  $nuke = drush_get_option('nuke');
-  $op = $nuke ? $nuke: 'preview';
+  $op = drush_get_option('op');
+  $op = $op ? $op: 'preview-dups';
+  $op = explode('-', $op);
+  $op = array('mode' => $op[0], 'scope' => $op[1]);
   $options = array(
     'collection-pids-file' => drush_get_option('collection-pids-file'),
     'exclude-pids' => drush_get_option('exclude-pids'),
     'collection_pids' => drush_get_option('collection-pids'),
     'timer' => drush_get_option('timer'),
     'mimetype' => $mimetype = drush_get_option('mimetype'),
+    'cm' => drush_get_option('cm'),
   );
   $options = array_filter($options);
   module_load_include('inc', 'islandora_datastream_dedup', 'includes/utilities');


### PR DESCRIPTION
…ent model, and improved and fixed bugs in preview. Changed options so that 'nuke' is no longer an option. Instead, you specify --op=nuke-dups, or -op=nuke-all if you want to actually delete datastreams. Defaults to --op=preview-dups.